### PR TITLE
add `move` variant of gen_iter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,9 @@ where
 macro_rules! gen_iter {
     ($block: block) => {
         $crate::GenIter(|| $block)
+    };
+    (move $block: block) => {
+        $crate::GenIter(move || $block)
     }
 }
 


### PR DESCRIPTION
In order to use `self` in the generator block, I need to `move` the reference into the generator. This PR adds that macro rule.

Example:

```rust
struct MyVec (Vec<u32>);

impl MyVec {
  fn iter(&self) {
    gen_iter!(move {
      for elem in self.0.iter() {
        yield elem;
      }
    })
  }
}
```

This would not work without the `move`, because rustc would complain that the reference-to-self  (of type reference-to-reference-to-MyVec) used in the generator expression lives longer than the `self reference`. Using `move` solves this.