### PR TITLE
GenIterReturn refactorings , and add more tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# version 0.4.1
+* tests refactorings, now it's 100% test coverage
+  - unit tests in 'src/' just use `core::*`
+  - integration tests in 'tests/' can use `std::*`
+  - move 'impl_generator' tests to 'tests/'
+  - add test for `#[derive(Debug)]` in 'impl_generator' tests
+
 # version 0.4.0
 * incompatible refactorings for `GenIterReturn`:
   - rename `GenIterReturn::is_done()` to `GenIterReturn::is_complete()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# version 0.4.0
+* incompatible refactorings for `GenIterReturn`:
+  - rename `GenIterReturn::is_done()` to `GenIterReturn::is_complete()`
+  - rename `GenIterReturn::return_or_self()` to `GenIterReturn::try_get_return()`
+* add tests for feature `generator_clone`
+* add tests those do not use closure but use `impl Generator`
+
+# version 0.3
+* made the crate no_std compatible (#5)
+* added struct GenIterReturn and macro gen_iter_return! to iterate over a generator and get the return value (#6)
+
 # version 0.2.1
 * added `move` varient of gen-iter (#4)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-iter"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["tinaun <tinagma@gmail.com>"]
 keywords = ["generator", "iterator"]
 description = "temporary util for creating iterators using generators"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-iter"
-version = "0.2.1"
+version = "0.4.0"
 authors = ["tinaun <tinagma@gmail.com>"]
 keywords = ["generator", "iterator"]
 description = "temporary util for creating iterators using generators"

--- a/src/gen_iter.rs
+++ b/src/gen_iter.rs
@@ -103,34 +103,4 @@ mod tests {
         assert_eq!(g.next(), Some(2));
         assert_eq!(g.next(), None);
     }
-
-    /// test customize generator using `impl Generator`
-    #[test]
-    fn impl_generator() {  
-        use core::ops::{Generator, GeneratorState};
-        use core::iter::Iterator;
-        use core::pin::Pin;
-
-        #[derive(Clone, Debug)]
-        struct G(i32);
-        impl Generator for G {
-            type Yield = i32;
-            type Return = ();
-            fn resume(mut self: Pin<&mut Self>, _: ()) -> GeneratorState<Self::Yield, Self::Return> {
-                let v = self.0;
-                if v > 0 {
-                    self.0 = v - 1;
-                    GeneratorState::Yielded(v)
-                } else {
-                    GeneratorState::Complete(())
-                }
-            }
-        }
-  
-        let g = G(1);
-        let mut g = GenIter(g);
-
-        assert_eq!((&mut g).next(), Some(1));
-        assert_eq!((&mut g).next(), None);
-    }
 }

--- a/src/gen_iter.rs
+++ b/src/gen_iter.rs
@@ -103,4 +103,34 @@ mod tests {
         assert_eq!(g.next(), Some(2));
         assert_eq!(g.next(), None);
     }
+
+    /// test customize generator using `impl Generator`
+    #[test]
+    fn impl_generator() {  
+        use core::ops::{Generator, GeneratorState};
+        use core::iter::Iterator;
+        use core::pin::Pin;
+
+        #[derive(Clone, Debug)]
+        struct G(i32);
+        impl Generator for G {
+            type Yield = i32;
+            type Return = ();
+            fn resume(mut self: Pin<&mut Self>, _: ()) -> GeneratorState<Self::Yield, Self::Return> {
+                let v = self.0;
+                if v > 0 {
+                    self.0 = v - 1;
+                    GeneratorState::Yielded(v)
+                } else {
+                    GeneratorState::Complete(())
+                }
+            }
+        }
+  
+        let g = G(1);
+        let mut g = GenIter(g);
+
+        assert_eq!((&mut g).next(), Some(1));
+        assert_eq!((&mut g).next(), None);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,8 @@
 //! for y in &mut g {
 //!     println!("yield {}", y);
 //! }
-//! println!("generator is_done={}", g.is_done()); // true
-//! println!("generator returns {}", g.return_or_self().ok().unwrap()); // "done"
+//! println!("generator is_complete={}", g.is_complete()); // true
+//! println!("generator returns {}", g.try_get_return().ok().unwrap()); // "done"
 //! ```
 
 #![no_std]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,6 @@
 
 #![no_std]
 #![feature(generators, generator_trait)]
-// #![feature(conservative_impl_trait)]
 
 mod gen_iter;
 pub use gen_iter::*;

--- a/tests/generator_clone.rs
+++ b/tests/generator_clone.rs
@@ -32,9 +32,9 @@ fn gen_iter_return_clone() {
     let mut g_cloned = g.clone();
     assert_eq!((&mut g_cloned).next(), Some(2));
     assert_eq!((&mut g_cloned).next(), None);
-    assert_eq!(g_cloned.return_or_self().ok(), Some("done"));
+    assert_eq!(g_cloned.try_get_return().ok(), Some("done"));
 
     assert_eq!((&mut g).next(), Some(2));
     assert_eq!((&mut g).next(), None);
-    assert_eq!(g.return_or_self().ok(), Some("done"));
+    assert_eq!(g.try_get_return().ok(), Some("done"));
 }

--- a/tests/generator_clone.rs
+++ b/tests/generator_clone.rs
@@ -19,7 +19,6 @@ fn gen_iter_clone() {
     assert_eq!((&mut g).next(), None);
 }
 
-    
 #[test]
 fn gen_iter_return_clone() {
     let mut g = gen_iter_return!(move {

--- a/tests/generator_clone.rs
+++ b/tests/generator_clone.rs
@@ -1,0 +1,40 @@
+#![feature(generators, generator_clone)]
+
+extern crate gen_iter;
+use gen_iter::*;
+
+#[test]
+fn gen_iter_clone() {
+    let mut g = gen_iter!(move {
+        yield 1;
+        yield 2;
+    });
+    assert_eq!((&mut g).next(), Some(1));
+
+    let mut g_cloned = g.clone();
+    assert_eq!((&mut g_cloned).next(), Some(2));
+    assert_eq!((&mut g_cloned).next(), None);
+
+    assert_eq!((&mut g).next(), Some(2));
+    assert_eq!((&mut g).next(), None);
+}
+
+    
+#[test]
+fn gen_iter_return_clone() {
+    let mut g = gen_iter_return!(move {
+        yield 1;
+        yield 2;
+        return "done";
+    });
+    assert_eq!((&mut g).next(), Some(1));
+
+    let mut g_cloned = g.clone();
+    assert_eq!((&mut g_cloned).next(), Some(2));
+    assert_eq!((&mut g_cloned).next(), None);
+    assert_eq!(g_cloned.return_or_self().ok(), Some("done"));
+
+    assert_eq!((&mut g).next(), Some(2));
+    assert_eq!((&mut g).next(), None);
+    assert_eq!(g.return_or_self().ok(), Some("done"));
+}

--- a/tests/impl_generator.rs
+++ b/tests/impl_generator.rs
@@ -1,0 +1,86 @@
+#![feature(generators, generator_trait)]
+
+extern crate gen_iter;
+use gen_iter::*;
+
+use std::ops::{Generator, GeneratorState};
+use std::iter::Iterator;
+use std::pin::Pin;
+use std::marker::PhantomPinned;
+use std::cell::RefCell;
+use std::format;
+
+/// test customize generator using `impl Generator`
+/// also test `#[derive(Debug)]`
+#[test]
+fn gen_iter_impl_generator() {
+    #[derive(Debug)]
+    struct G(i32);
+    impl Generator for G {
+        type Yield = i32;
+        type Return = ();
+        fn resume(mut self: Pin<&mut Self>, _: ()) -> GeneratorState<Self::Yield, Self::Return> {
+            let v = self.0;
+            if v > 0 {
+                self.0 = v - 1;
+                GeneratorState::Yielded(v)
+            } else {
+                GeneratorState::Complete(())
+            }
+        }
+    }
+
+    let g = G(1);
+    let mut g = GenIter(g);
+
+    assert_eq!(format!("{:?}", g), "GenIter(G(1))");
+    assert_eq!((&mut g).next(), Some(1));
+    assert_eq!(format!("{:?}", g), "GenIter(G(0))");
+    assert_eq!((&mut g).next(), None);
+    assert_eq!(format!("{:?}", g), "GenIter(G(0))");
+}
+
+/// test customize generator using `impl Generator` which is `!Unpin`
+/// also test `#[derive(Debug)]`
+#[test]
+fn gen_iter_return_impl_generator_not_unpin() {
+    #[derive(Debug)]
+    struct G(RefCell<i32>, PhantomPinned);
+    impl G {
+        pub fn new(v: i32) -> Self {
+            G(RefCell::new(v), PhantomPinned)
+        }
+    }
+    impl Generator for G {
+        type Yield = i32;
+        type Return = &'static str;
+        fn resume(self: Pin<&mut Self>, _: ()) -> GeneratorState<Self::Yield, Self::Return> {
+            let v = *self.0.borrow();
+            if v > 0 {
+                *self.0.borrow_mut() -= 1;
+                GeneratorState::Yielded(v)
+            } else {
+                GeneratorState::Complete("done")
+            }
+        }
+    }
+
+    let mut g = G::new(1);
+    let pin_g = unsafe { Pin::new_unchecked(&mut g) };
+    let mut g = GenIterReturn::new(pin_g);
+
+    assert_eq!(format!("{:?}", g), "GenIterReturn(Err(G(RefCell { value: 1 }, PhantomPinned)))");
+    assert_eq!((&mut g).next(), Some(1));
+    assert_eq!(g.is_complete(), false);
+
+    g = g.try_get_return().expect_err("unexpected generator state: is_complete");
+    
+    assert_eq!(format!("{:?}", g), "GenIterReturn(Err(G(RefCell { value: 0 }, PhantomPinned)))");
+    assert_eq!((&mut g).next(), None);
+    assert_eq!(format!("{:?}", g), "GenIterReturn(Ok(\"done\"))");
+    assert_eq!(g.is_complete(), true);
+
+    assert_eq!((&mut g).next(), None); // it won't panic when call `next()` even exhausted.
+
+    assert_eq!(g.try_get_return().ok(), Some("done"));
+}


### PR DESCRIPTION
# version 0.4.0
* incompatible refactorings for `GenIterReturn`:
  - rename `GenIterReturn::is_done()` to `GenIterReturn::is_complete()`
  - rename `GenIterReturn::return_or_self()` to `GenIterReturn::try_get_return()`
* add tests for feature `generator_clone`
* add tests those do not use closure but use `impl Generator`