### PR TITLE
Renamed generators to coroutines as per rust's updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-iter"
-version = "0.2.1"
+version = "0.4.0"
 authors = ["tinaun <tinagma@gmail.com>"]
 keywords = ["generator", "iterator"]
 description = "temporary util for creating iterators using generators"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/src/gen_iter_return.rs
+++ b/src/gen_iter_return.rs
@@ -1,19 +1,19 @@
-use core::ops::{Generator, GeneratorState};
-use core::iter::{Iterator, FusedIterator};
+use core::iter::{FusedIterator, Iterator};
 use core::marker::Unpin;
+use core::ops::{Coroutine, CoroutineState};
 use core::pin::Pin;
 
 /// `GenIterReturn<G>` holds a generator `G` or the return value of `G`,
 /// `&mut GenIterReturn<G>` acts as an iterator.
-/// 
+///
 /// Differences with `GenIter<G>`:
 /// 1. able to get return value of a generator
 /// 2. safe to call `next()` after generator is done without panic
 /// 3. maybe less efficient than `GenIter<G>`
 #[derive(Copy, Clone, Debug)]
-pub struct GenIterReturn<G: Generator + Unpin>(Result<G::Return, G>);
+pub struct GenIterReturn<G: Coroutine + Unpin>(Result<G::Return, G>);
 
-impl<G: Generator + Unpin> GenIterReturn<G> {
+impl<G: Coroutine + Unpin> GenIterReturn<G> {
     #[inline]
     pub fn new(g: G) -> Self {
         GenIterReturn(Err(g))
@@ -37,13 +37,13 @@ impl<G: Generator + Unpin> GenIterReturn<G> {
 /// in which return value cannot be got.
 /// ```compile_fail
 /// // !!INVALID CODE!!
-/// # #![feature(generators)]
+/// # #![feature(coroutines)]
 /// # use gen_iter::gen_iter_return;
 /// let mut g = gen_iter_return!({ yield 1; return "done"; });
 /// for v in g {} // invalid, because `GenIterReturn<G>` is not `Iterator`
 /// let ret = g.return_or_self(); // g is dropped after for loop
 /// ```
-impl<G: Generator + Unpin> Iterator for &mut GenIterReturn<G> {
+impl<G: Coroutine + Unpin> Iterator for &mut GenIterReturn<G> {
     type Item = G::Yield;
 
     #[inline]
@@ -51,20 +51,20 @@ impl<G: Generator + Unpin> Iterator for &mut GenIterReturn<G> {
         match self.0 {
             Ok(_) => None,
             Err(ref mut g) => match Pin::new(g).resume(()) {
-                GeneratorState::Yielded(y) => Some(y),
-                GeneratorState::Complete(r) => {
+                CoroutineState::Yielded(y) => Some(y),
+                CoroutineState::Complete(r) => {
                     self.0 = Ok(r);
                     None
-                },
-            }
+                }
+            },
         }
     }
 }
 
 /// `GenIterReturn<G>` satisfies the trait `FusedIterator`
-impl<G: Generator + Unpin> FusedIterator for &mut GenIterReturn<G> {}
+impl<G: Coroutine + Unpin> FusedIterator for &mut GenIterReturn<G> {}
 
-impl<G: Generator + Unpin> From<G> for GenIterReturn<G> {
+impl<G: Coroutine + Unpin> From<G> for GenIterReturn<G> {
     #[inline]
     fn from(g: G) -> Self {
         GenIterReturn::new(g)
@@ -73,7 +73,7 @@ impl<G: Generator + Unpin> From<G> for GenIterReturn<G> {
 
 /// macro to simplify iterator - via - generator with return value construction
 /// ```
-/// #![feature(generators)]
+/// #![feature(coroutines)]
 ///
 /// use gen_iter::gen_iter_return;
 ///
@@ -95,7 +95,7 @@ macro_rules! gen_iter_return {
     };
     (move $block: block) => {
         $crate::GenIterReturn::new(move || $block)
-    }
+    };
 }
 
 #[cfg(test)]
@@ -116,7 +116,7 @@ mod tests {
 
         g = match g.return_or_self() {
             Ok(_) => panic!("generator is done but should not"),
-            Err(g) => g
+            Err(g) => g,
         };
 
         assert_eq!((&mut g).next(), None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,11 @@
 //! ## [`GenIter`] and [`gen_iter!`]
 //! [`GenIter`] converts a [`Generator<(), Return=()>`](core::ops::Generator) into an iterator over the
 //! yielded type of the generator. The return type of the generator needs to be `()`.
-//! 
+//!
 //! [`gen_iter!`] helps to create a [`GenIter`]
 //!
 //! ```
-//! #![feature(generators)]
+//! #![feature(coroutines)]
 //!
 //! use gen_iter::gen_iter;
 //!
@@ -30,16 +30,16 @@
 //!     println!("{}", elem);
 //! }
 //! ```
-//! 
+//!
 //! ## [`GenIterReturn`] and [`gen_iter_return!`]
 //! [`GenIterReturn`] can be converted from a [`Generator<()>`](core::ops::Generator),
 //! `&mut GenIterReturn<G>` can be used as iterator.
 //! The return value of the generator can be got after the iterator is exhausted.
-//! 
+//!
 //! [`gen_iter_return!`] helps to create a [`GenIterReturn`].
-//! 
+//!
 //! ```
-//! #![feature(generators)]
+//! #![feature(coroutines)]
 //!
 //! use gen_iter::gen_iter_return;
 //!
@@ -48,7 +48,7 @@
 //!     yield 2;
 //!     return "done";
 //! });
-//! 
+//!
 //! for y in &mut g {
 //!     println!("yield {}", y);
 //! }
@@ -57,7 +57,7 @@
 //! ```
 
 #![no_std]
-#![feature(generators, generator_trait)]
+#![feature(coroutines, coroutine_trait)]
 
 mod gen_iter;
 pub use gen_iter::*;


### PR DESCRIPTION
Rust recently renamed generators to coroutines, as seen here:
> https://blog.rust-lang.org/inside-rust/2023/10/23/coroutines.html

This broke gen_iter in my dependency tree, so I'm making this PR