### PR TITLE
rename Generator to Coroutine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# version 0.4.1
+* add support for immovable coroutine (self-referenced)
+* change the varialble name `gen` as it will be a keyword in edition2024
+
 # version 0.4.0
 * follow [rename Generator to Coroutine](https://github.com/rust-lang/rust/pull/116958) and fix #10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# version 0.4.0
+* follow [rename Generator to Coroutine](https://github.com/rust-lang/rust/pull/116958) and fix #10
+
 # version 0.3
 * made the crate no_std compatible (#5)
 * added struct GenIterReturn and macro gen_iter_return! to iterate over a generator and get the return value (#6)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-iter"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["tinaun <tinagma@gmail.com>"]
 keywords = ["coroutine", "generator", "iterator"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "gen-iter"
-version = "0.2.1"
+version = "0.4.0"
+edition = "2021"
 authors = ["tinaun <tinagma@gmail.com>"]
-keywords = ["generator", "iterator"]
-description = "temporary util for creating iterators using generators"
+keywords = ["coroutine", "generator", "iterator"]
+description = "temporary util for creating iterators using coroutines"
 
 documentation = "https://docs.rs/gen-iter"
 repository = "https://github.com/tinaun/gen-iter"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gen_iter - iterators using generators.
+# gen_iter - iterators using coroutines/generators.
 
 see [the docs](https://docs.rs/gen-iter) for examples and usage.
 

--- a/src/gen_iter.rs
+++ b/src/gen_iter.rs
@@ -1,33 +1,33 @@
-use core::ops::{Generator, GeneratorState};
 use core::iter::Iterator;
 use core::marker::Unpin;
+use core::ops::{Coroutine, CoroutineState};
 use core::pin::Pin;
 
-/// an iterator that holds an internal generator representing
+/// an iterator that holds an internal coroutine representing
 /// the iteration state
 #[derive(Copy, Clone, Debug)]
 pub struct GenIter<T>(pub T)
 where
-    T: Generator<Return = ()> + Unpin;
+    T: Coroutine<Return = ()> + Unpin;
 
 impl<T> Iterator for GenIter<T>
 where
-    T: Generator<Return = ()> + Unpin,
+    T: Coroutine<Return = ()> + Unpin,
 {
     type Item = T::Yield;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         match Pin::new(&mut self.0).resume(()) {
-            GeneratorState::Yielded(n) => Some(n),
-            GeneratorState::Complete(()) => None,
+            CoroutineState::Yielded(n) => Some(n),
+            CoroutineState::Complete(()) => None,
         }
     }
 }
 
 impl<G> From<G> for GenIter<G>
 where
-    G: Generator<Return = ()> + Unpin,
+    G: Coroutine<Return = ()> + Unpin,
 {
     #[inline]
     fn from(gen: G) -> Self {
@@ -36,10 +36,10 @@ where
 }
 
 
-/// macro to simplify iterator - via - generator construction
+/// macro to simplify iterator - via - coroutine construction
 ///
 /// ```
-/// #![feature(generators)]
+/// #![feature(coroutines)]
 ///
 /// use gen_iter::gen_iter;
 ///
@@ -56,10 +56,10 @@ where
 #[macro_export]
 macro_rules! gen_iter {
     ($block: block) => {
-        $crate::GenIter(|| $block)
+        $crate::GenIter(#[coroutine] || $block)
     };
     (move $block: block) => {
-        $crate::GenIter(move || $block)
+        $crate::GenIter(#[coroutine] move || $block)
     }
 }
 
@@ -82,10 +82,13 @@ mod tests {
 
     #[test]
     fn into_gen_iter() {
-        let mut g: GenIter<_> = (|| {
-            yield 1;
-            yield 2;
-        }).into();
+        let mut g: GenIter<_> = (
+            #[coroutine]
+            || {
+                yield 1;
+                yield 2;
+            }
+        ).into();
 
         assert_eq!(g.next(), Some(1));
         assert_eq!(g.next(), Some(2));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,23 @@
 //! println!("coroutine is_done={}", g.is_done()); // true
 //! println!("coroutine returns {}", g.return_or_self().ok().unwrap()); // "done"
 //! ```
+//! 
+//! ## support immovable coroutine (self-referenced)
+//! ```
+//! #![feature(coroutines)]
+//!
+//! use gen_iter::gen_iter;
+//!
+//! let arr = [1, 2];
+//! let mut g = gen_iter!(static move {
+//!     let v = &arr;
+//!     for i in 0..v.len() {
+//!         yield v[i];
+//!     }
+//! });
+//!
+//! assert_eq!(g.collect::<Vec<i32>>(), [1, 2]);
+//! ```
 
 #![no_std]
 #![feature(coroutines, coroutine_trait)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! [`GenIter`] converts a [`Coroutine<(), Return=()>`](core::ops::Coroutine) into an iterator over the
 //! yielded type of the coroutine. The return type of the coroutine needs to be `()`.
 //!
-//! [`gen_iter!`] helps to create a [`GenIter`]
+//! ### [`gen_iter!`] helps to create a [`GenIter`]
 //!
 //! ```
 //! #![feature(coroutines)]
@@ -35,13 +35,47 @@
 //!     println!("{}", elem);
 //! }
 //! ```
+//! ### compare to gen block in edition2024
+//! 
+//! <div style="display:flex; gap: 2rem">
+//! <div>
+//! 
+//! ```ignore
+//! # #![feature(coroutines)]
+//! #![feature(gen_blocks)]
+//! let gen1 = gen {
+//!     yield 1;
+//!     yield 2;
+//! };
+//! for x in gen1 {
+//!     println!("{x}");
+//! }
+//! ```
+//! 
+//! </div>
+//! <div>
+//! 
+//! ```
+//! # #![feature(coroutines)]
+//! use gen_iter::gen_iter;
+//! let gen1 = gen_iter!({
+//!     yield 1;
+//!     yield 2;
+//! });
+//! for x in gen1 {
+//!     println!("{x}");
+//! }
+//! ```
+//! 
+//! </div>
+//! </div>
 //! 
 //! ## [`GenIterReturn`] and [`gen_iter_return!`]
 //! [`GenIterReturn`] can be converted from a [`Coroutine<()>`](core::ops::Coroutine),
 //! `&mut GenIterReturn<G>` can be used as iterator.
 //! The return value of the coroutine can be got after the iterator is exhausted.
 //! 
-//! [`gen_iter_return!`] helps to create a [`GenIterReturn`].
+//! ### [`gen_iter_return!`] helps to create a [`GenIterReturn`].
 //! 
 //! ```
 //! #![feature(coroutines)]
@@ -62,6 +96,8 @@
 //! ```
 //! 
 //! ## support immovable coroutine (self-referenced)
+//! The created `GenIter<_>` cannot be moved out of current stack frame,
+//! cause the underlying coroutine is pinned in stack.
 //! ```
 //! #![feature(coroutines)]
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,18 @@
-//! # gen_iter - create generators to use as iterators
-//!
-//! ## [`GenIter`] and [`gen_iter!`]
-//! [`GenIter`] converts a [`Generator<(), Return=()>`](core::ops::Generator) into an iterator over the
-//! yielded type of the generator. The return type of the generator needs to be `()`.
+//! # gen_iter - create coroutines to use as iterators
 //! 
+//! **Important: [rename Generator to Coroutine](https://github.com/rust-lang/rust/pull/116958)**
+//!
+//! ## Prerequirements
+//! Nightly rust toolchain of edition 2021 after 2023-10-21.
+//! 
+//! ## [`GenIter`] and [`gen_iter!`]
+//! [`GenIter`] converts a [`Coroutine<(), Return=()>`](core::ops::Coroutine) into an iterator over the
+//! yielded type of the coroutine. The return type of the coroutine needs to be `()`.
+//!
 //! [`gen_iter!`] helps to create a [`GenIter`]
 //!
 //! ```
-//! #![feature(generators)]
+//! #![feature(coroutines)]
 //!
 //! use gen_iter::gen_iter;
 //!
@@ -32,14 +37,14 @@
 //! ```
 //! 
 //! ## [`GenIterReturn`] and [`gen_iter_return!`]
-//! [`GenIterReturn`] can be converted from a [`Generator<()>`](core::ops::Generator),
+//! [`GenIterReturn`] can be converted from a [`Coroutine<()>`](core::ops::Coroutine),
 //! `&mut GenIterReturn<G>` can be used as iterator.
-//! The return value of the generator can be got after the iterator is exhausted.
+//! The return value of the coroutine can be got after the iterator is exhausted.
 //! 
 //! [`gen_iter_return!`] helps to create a [`GenIterReturn`].
 //! 
 //! ```
-//! #![feature(generators)]
+//! #![feature(coroutines)]
 //!
 //! use gen_iter::gen_iter_return;
 //!
@@ -52,12 +57,13 @@
 //! for y in &mut g {
 //!     println!("yield {}", y);
 //! }
-//! println!("generator is_done={}", g.is_done()); // true
-//! println!("generator returns {}", g.return_or_self().ok().unwrap()); // "done"
+//! println!("coroutine is_done={}", g.is_done()); // true
+//! println!("coroutine returns {}", g.return_or_self().ok().unwrap()); // "done"
 //! ```
 
 #![no_std]
-#![feature(generators, generator_trait)]
+#![feature(coroutines, coroutine_trait)]
+#![feature(stmt_expr_attributes)]
 
 mod gen_iter;
 pub use gen_iter::*;


### PR DESCRIPTION
follow [rename Generator to Coroutine](https://github.com/rust-lang/rust/pull/116958) and fix #10

add support for immovable coroutine (self referenced)
```rust
let mut g = gen_iter!(static {
    let v1 = [1, 2];
    let v = &v1;
    for i in 0..v.len() {
        yield v[i];
    }
});

assert_eq!(g.next(), Some(1));
assert_eq!(g.next(), Some(2));
assert_eq!(g.next(), None);
```